### PR TITLE
Switch repo from apple to swiftlang, bump version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -30,7 +30,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", from: "509.1.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", from: "509.1.0"),
     // We only really need swift-macro-testing 0.3.0 or newer but 0.4.0 is required to compile due
     // to breaking changes in swift-snapshot-testing.
     .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.4.0"),


### PR DESCRIPTION
Apple moved the repo to swiftlang, so this points to new repo. Bumps `from` version to 601.0.0.